### PR TITLE
Fix nat-pmp bug. Bump to v1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-electron",
-  "version": "1.7.0",
+  "version": "1.7.2",
   "main": "index.js",
   "repository": "https://github.com/irislib/iris-electron",
   "author": "Martti Malmi <sirius@iki.fi>",


### PR DESCRIPTION
This update allowed me to `yarn build` and run on Ubuntu 20.04.2 LTS on the default Ubuntu desktop.